### PR TITLE
Feat/exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/artrun/artrun/domain/auth/SecurityUtil.java
+++ b/src/main/java/artrun/artrun/domain/auth/SecurityUtil.java
@@ -2,6 +2,7 @@ package artrun.artrun.domain.auth;
 
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -12,7 +13,7 @@ public class SecurityUtil {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || authentication.getName() == null) {
-            throw new RuntimeException("Security Context에 인증 정보가 없습니다.");
+            throw new AuthenticationServiceException("Security Context에 인증 정보가 없습니다.");
         }
 
         return Long.parseLong(authentication.getName());
@@ -23,16 +24,15 @@ public class SecurityUtil {
      * 해당 memberId가 본인이 맞는지 token과 비교하여 검증
      * @param memberId
      */
-    // TODO Exception 개선
     public static Boolean isAuthorizedByMemberId(Long memberId) {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || authentication.getName() == null) {
-            throw new RuntimeException("Security Context에 인증 정보가 없습니다.");
+            throw new AuthenticationServiceException("Security Context에 인증 정보가 없습니다.");
         }
 
         if (Long.parseLong(authentication.getName()) != memberId) {
-            throw new RuntimeException("토큰과 일치하지 않는 memberId입니다.");
+            throw new AuthenticationServiceException("토큰과 일치하지 않는 memberId입니다.");
         }
 
         return true;

--- a/src/main/java/artrun/artrun/domain/auth/TokenProvider.java
+++ b/src/main/java/artrun/artrun/domain/auth/TokenProvider.java
@@ -1,6 +1,6 @@
 package artrun.artrun.domain.auth;
 
-import artrun.artrun.domain.auth.dto.TokenDto;
+import artrun.artrun.domain.auth.dto.TokenResponseDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -36,7 +36,7 @@ public class TokenProvider {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public TokenDto generateTokenDto(Authentication authentication) {
+    public TokenResponseDto generateTokenDto(Authentication authentication) {
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
@@ -56,7 +56,7 @@ public class TokenProvider {
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
 
-        return TokenDto.builder()
+        return TokenResponseDto.builder()
                 .grantType(BEARER_TYPE)
                 .accessToken(accessToken)
                 .accessTokenExpiresIn(accessTokenExpiresIn.getTime())

--- a/src/main/java/artrun/artrun/domain/auth/controller/AuthController.java
+++ b/src/main/java/artrun/artrun/domain/auth/controller/AuthController.java
@@ -2,12 +2,14 @@ package artrun.artrun.domain.auth.controller;
 
 import artrun.artrun.domain.auth.dto.AuthRequestDto;
 import artrun.artrun.domain.auth.dto.AuthResponseDto;
-import artrun.artrun.domain.auth.dto.TokenDto;
+import artrun.artrun.domain.auth.dto.TokenResponseDto;
 import artrun.artrun.domain.auth.dto.TokenRequestDto;
 import artrun.artrun.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/auth")
@@ -16,17 +18,17 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<AuthResponseDto> signup(@RequestBody AuthRequestDto memberRequestDto) {
+    public ResponseEntity<AuthResponseDto> signup(@RequestBody @Valid AuthRequestDto memberRequestDto) {
         return ResponseEntity.ok(authService.signup(memberRequestDto));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenDto> login(@RequestBody AuthRequestDto memberRequestDto) {
+    public ResponseEntity<TokenResponseDto> login(@RequestBody @Valid AuthRequestDto memberRequestDto) {
         return ResponseEntity.ok(authService.login(memberRequestDto));
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<TokenDto> reissue(@RequestBody TokenRequestDto tokenRequestDto) {
+    public ResponseEntity<TokenResponseDto> reissue(@RequestBody @Valid TokenRequestDto tokenRequestDto) {
         return ResponseEntity.ok(authService.reissue(tokenRequestDto));
     }
 }

--- a/src/main/java/artrun/artrun/domain/auth/controller/AuthController.java
+++ b/src/main/java/artrun/artrun/domain/auth/controller/AuthController.java
@@ -4,12 +4,15 @@ import artrun.artrun.domain.auth.dto.AuthRequestDto;
 import artrun.artrun.domain.auth.dto.AuthResponseDto;
 import artrun.artrun.domain.auth.dto.TokenResponseDto;
 import artrun.artrun.domain.auth.dto.TokenRequestDto;
+import artrun.artrun.domain.auth.exception.AuthenticationException;
 import artrun.artrun.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+
+import static artrun.artrun.global.error.exception.ErrorCode.UNAUTHORIZED;
 
 @RestController
 @RequestMapping("/auth")
@@ -30,5 +33,10 @@ public class AuthController {
     @PostMapping("/reissue")
     public ResponseEntity<TokenResponseDto> reissue(@RequestBody @Valid TokenRequestDto tokenRequestDto) {
         return ResponseEntity.ok(authService.reissue(tokenRequestDto));
+    }
+
+    @GetMapping("/exception")
+    public void exception() {
+        throw new AuthenticationException(UNAUTHORIZED);
     }
 }

--- a/src/main/java/artrun/artrun/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/artrun/artrun/domain/auth/dto/AuthRequestDto.java
@@ -7,10 +7,15 @@ import lombok.Setter;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
 @Getter
 @Setter
 public class AuthRequestDto {
+    @Email
     private String email;
+    @NotEmpty
     private String password;
 
 

--- a/src/main/java/artrun/artrun/domain/auth/dto/TokenRequestDto.java
+++ b/src/main/java/artrun/artrun/domain/auth/dto/TokenRequestDto.java
@@ -3,9 +3,13 @@ package artrun.artrun.domain.auth.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotEmpty;
+
 @Getter
 @Setter
 public class TokenRequestDto {
+    @NotEmpty
     private String accessToken;
+    @NotEmpty
     private String refreshToken;
 }

--- a/src/main/java/artrun/artrun/domain/auth/dto/TokenResponseDto.java
+++ b/src/main/java/artrun/artrun/domain/auth/dto/TokenResponseDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class TokenDto {
+public class TokenResponseDto {
 
     private String grantType;
     private String accessToken;

--- a/src/main/java/artrun/artrun/domain/auth/exception/AuthenticationException.java
+++ b/src/main/java/artrun/artrun/domain/auth/exception/AuthenticationException.java
@@ -1,0 +1,12 @@
+package artrun.artrun.domain.auth.exception;
+
+import artrun.artrun.global.error.exception.BusinessException;
+import artrun.artrun.global.error.exception.ErrorCode;
+
+
+public class AuthenticationException extends BusinessException {
+
+    public AuthenticationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/artrun/artrun/domain/auth/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/artrun/artrun/domain/auth/exception/JwtAuthenticationEntryPoint.java
@@ -13,7 +13,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
-        // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        // 유효한 자격증명을 제공하지 않고 접근하려 할때 unauthorized exception (401)
+        response.sendRedirect("/auth/exception");
     }
 }

--- a/src/main/java/artrun/artrun/domain/auth/service/AuthService.java
+++ b/src/main/java/artrun/artrun/domain/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import artrun.artrun.domain.auth.dto.AuthRequestDto;
 import artrun.artrun.domain.auth.dto.AuthResponseDto;
 import artrun.artrun.domain.auth.dto.TokenResponseDto;
 import artrun.artrun.domain.auth.dto.TokenRequestDto;
+import artrun.artrun.domain.auth.exception.AuthenticationException;
 import artrun.artrun.domain.auth.repository.RefreshTokenRepository;
 import artrun.artrun.domain.member.domain.Member;
 import artrun.artrun.domain.member.repository.MemberRepository;
@@ -16,6 +17,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static artrun.artrun.global.error.exception.ErrorCode.EMAIL_DUPLICATION;
 
 
 @Service
@@ -30,7 +33,7 @@ public class AuthService {
 
     public AuthResponseDto signup(AuthRequestDto authRequestDto) {
         if(memberRepository.existsByEmail(authRequestDto.getEmail())) {
-            throw new RuntimeException("이미 가입되어 있는 유저입니다.");
+            throw new AuthenticationException(EMAIL_DUPLICATION);
         }
 
         Member member = authRequestDto.toMember(passwordEncoder);

--- a/src/main/java/artrun/artrun/domain/auth/service/AuthService.java
+++ b/src/main/java/artrun/artrun/domain/auth/service/AuthService.java
@@ -4,7 +4,7 @@ import artrun.artrun.domain.auth.TokenProvider;
 import artrun.artrun.domain.auth.domain.RefreshToken;
 import artrun.artrun.domain.auth.dto.AuthRequestDto;
 import artrun.artrun.domain.auth.dto.AuthResponseDto;
-import artrun.artrun.domain.auth.dto.TokenDto;
+import artrun.artrun.domain.auth.dto.TokenResponseDto;
 import artrun.artrun.domain.auth.dto.TokenRequestDto;
 import artrun.artrun.domain.auth.repository.RefreshTokenRepository;
 import artrun.artrun.domain.member.domain.Member;
@@ -37,7 +37,7 @@ public class AuthService {
         return AuthResponseDto.of(memberRepository.save(member));
     }
 
-    public TokenDto login(AuthRequestDto authRequestDto) {
+    public TokenResponseDto login(AuthRequestDto authRequestDto) {
         // 1. Login ID/PW 를 기반으로 AuthenticationToken 생성
         UsernamePasswordAuthenticationToken authenticationToken = authRequestDto.toAuthentication();
 
@@ -47,7 +47,7 @@ public class AuthService {
                 .authenticate(authenticationToken);
 
         // 3. authentication 기반으로 JWT 토큰 생성
-        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+        TokenResponseDto tokenDto = tokenProvider.generateTokenDto(authentication);
 
         // 4. RefreshToken 저장
         RefreshToken refreshToken = RefreshToken.builder()
@@ -61,7 +61,7 @@ public class AuthService {
         return tokenDto;
     }
 
-    public TokenDto reissue(TokenRequestDto tokenRequestDto) {
+    public TokenResponseDto reissue(TokenRequestDto tokenRequestDto) {
         // 1. RefreshToken 검증
         if (!tokenProvider.validateToken(tokenRequestDto.getRefreshToken())) {
             throw new RuntimeException("Refresh Token이 유효하지 않습니다.");
@@ -80,7 +80,7 @@ public class AuthService {
         }
 
         // 5. 새로운 토큰 생성
-        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+        TokenResponseDto tokenDto = tokenProvider.generateTokenDto(authentication);
 
         // 6. 저장소에 Refresh Token 업데이트
         RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());

--- a/src/main/java/artrun/artrun/domain/route/controller/RouteController.java
+++ b/src/main/java/artrun/artrun/domain/route/controller/RouteController.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequestMapping("/route")
 @AllArgsConstructor
@@ -17,17 +19,17 @@ public class RouteController {
     private final RouteFindService routeFindService;
 
     @GetMapping("/{routeId}")
-    public ResponseEntity<RouteResponseDto> get(@PathVariable Long routeId) {
+    public ResponseEntity<RouteResponseDto> get(@PathVariable @Valid Long routeId) {
         return ResponseEntity.ok(RouteResponseDto.of(routeFindService.get(routeId)));
     }
 
     @PostMapping("/start")
-    public ResponseEntity<RouteStartResponseDto> start(@RequestBody RouteStartRequestDto routeStartRequestDto) {
+    public ResponseEntity<RouteStartResponseDto> start(@RequestBody @Valid RouteStartRequestDto routeStartRequestDto) {
         return ResponseEntity.ok(routeRunService.start(routeStartRequestDto));
     }
 
     @PostMapping("/finish")
-    public ResponseEntity<RouteFinishResponseDto> finish(@RequestBody RouteFinishRequestDto routeFinishRequestDto) {
+    public ResponseEntity<RouteFinishResponseDto> finish(@RequestBody @Valid RouteFinishRequestDto routeFinishRequestDto) {
         return ResponseEntity.ok(routeRunService.finish(routeFinishRequestDto));
     }
 }

--- a/src/main/java/artrun/artrun/domain/route/dto/RouteFinishRequestDto.java
+++ b/src/main/java/artrun/artrun/domain/route/dto/RouteFinishRequestDto.java
@@ -4,21 +4,42 @@ import artrun.artrun.domain.route.domain.Route;
 import artrun.artrun.global.util.wktToGeometry;
 import lombok.*;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class RouteFinishRequestDto {
+    @Positive
     private Long routeId;
+
+    @Positive
     private Long memberId;
+
+    @NotEmpty
     private String wktRunRoute;
+
+    @NotEmpty
     private String title;
+
+    @PositiveOrZero
     private int distance;
+
+    @PositiveOrZero
     private int time;
+
+    @PositiveOrZero
     private int kcal;
+
+    @NotEmpty
     private String color;
+
     private Byte thickness;
+
     private Boolean isPublic;
 
     public Route toRoute() {

--- a/src/main/java/artrun/artrun/domain/route/dto/RouteStartRequestDto.java
+++ b/src/main/java/artrun/artrun/domain/route/dto/RouteStartRequestDto.java
@@ -5,13 +5,20 @@ import artrun.artrun.domain.route.domain.Route;
 import artrun.artrun.global.util.wktToGeometry;
 import lombok.*;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Positive;
+
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class RouteStartRequestDto {
+
+    @Positive
     private Long memberId;
+
+    @NotEmpty
     private String wktTargetRoute;
 
     public Route toRoute() {

--- a/src/main/java/artrun/artrun/domain/route/service/RouteFindService.java
+++ b/src/main/java/artrun/artrun/domain/route/service/RouteFindService.java
@@ -13,6 +13,7 @@ public class RouteFindService {
 
     private final RouteRepository routeRepository;
 
+    // TODO Use DTO
     public Route get(Long routeId) {
         return routeRepository.getById(routeId);
     }

--- a/src/main/java/artrun/artrun/global/error/ErrorResponse.java
+++ b/src/main/java/artrun/artrun/global/error/ErrorResponse.java
@@ -1,0 +1,83 @@
+package artrun.artrun.global.error;
+
+import artrun.artrun.global.error.exception.ErrorCode;
+import lombok.*;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+    private String message;
+    private List<FieldError> errors;
+    private String code;
+
+
+    private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+        this.message = code.getMessage();
+        this.errors = errors;
+        this.code = code.getCode();
+    }
+
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.errors = new ArrayList<>();
+        this.code = code.getCode();
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+        return new ErrorResponse(code, errors);
+    }
+
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        final String value = e.getValue() == null ? "" : e.getValue().toString();
+        final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of(e.getName(), value, e.getErrorCode());
+        return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        private FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(final String field, final String value, final String reason) {
+            List<FieldError> fieldErrors = new ArrayList<>();
+            fieldErrors.add(new FieldError(field, value, reason));
+            return fieldErrors;
+        }
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+}

--- a/src/main/java/artrun/artrun/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/artrun/artrun/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,88 @@
+package artrun.artrun.global.error;
+
+import artrun.artrun.global.error.exception.BusinessException;
+import artrun.artrun.global.error.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     *  javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
+     *  HttpMessageConverter 에서 등록한 HttpMessageConverter binding 못할경우 발생
+     *  주로 @RequestBody, @RequestPart 어노테이션에서 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * @ModelAttribute 으로 binding error 발생시 BindException 발생한다.
+     * ref https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args
+     */
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * enum type 일치하지 않아 binding 못할 경우 발생
+     * 주로 @RequestParam enum으로 binding 못했을 경우 발생
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        final ErrorResponse response = ErrorResponse.of(e);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 지원하지 않은 HTTP method 호출 할 경우 발생
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * Authentication 객체가 필요한 권한을 보유하지 않은 경우 발생합
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+        log.error("handleBusinessException", e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/artrun/artrun/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/artrun/artrun/global/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -71,7 +72,7 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
     }
 
-    @ExceptionHandler(BusinessException.class)
+    @ExceptionHandler({BusinessException.class, AuthenticationException.class})
     protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
         log.error("handleBusinessException", e);
         final ErrorCode errorCode = e.getErrorCode();

--- a/src/main/java/artrun/artrun/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/artrun/artrun/global/error/GlobalExceptionHandler.java
@@ -14,6 +14,9 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import javax.persistence.EntityNotFoundException;
+
+
 @ControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
@@ -70,6 +73,14 @@ public class GlobalExceptionHandler {
         log.error("handleAccessDeniedException", e);
         final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
         return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(final EntityNotFoundException e) {
+        log.error("handleEntityNotFoundException", e);
+        final ErrorCode errorCode = ErrorCode.ENTITY_NOT_FOUND;
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
     }
 
     @ExceptionHandler({BusinessException.class, AuthenticationException.class})

--- a/src/main/java/artrun/artrun/global/error/exception/BusinessException.java
+++ b/src/main/java/artrun/artrun/global/error/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package artrun.artrun.global.error.exception;
+
+public class BusinessException extends RuntimeException {
+    private ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/src/main/java/artrun/artrun/global/error/exception/ErrorCode.java
+++ b/src/main/java/artrun/artrun/global/error/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package artrun.artrun.global.error.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@Getter
+
+public enum ErrorCode {
+    // Common
+    INVALID_INPUT_VALUE(400, "C001", " Invalid Input Value"),
+    METHOD_NOT_ALLOWED(405, "C002", " Invalid Input Value"),
+    ENTITY_NOT_FOUND(400, "C003", " Entity Not Found"),
+    INTERNAL_SERVER_ERROR(500, "C004", "Server Error"),
+    INVALID_TYPE_VALUE(400, "C005", " Invalid Type Value"),
+    HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied"),
+
+    // Member
+    EMAIL_DUPLICATION(400, "M001", "Email is Duplication"),
+    LOGIN_INPUT_INVALID(400, "M002", "Login input is invalid"),
+
+    // Coupon
+    COUPON_ALREADY_USE(400, "CO001", "Coupon was already used"),
+    COUPON_EXPIRE(400, "CO002", "Coupon was already expired");
+
+    private final String code;
+    private final String message;
+    private int status;
+
+    ErrorCode(final int status, final String code, final String message) {
+        this.status = status;
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/src/main/java/artrun/artrun/global/error/exception/ErrorCode.java
+++ b/src/main/java/artrun/artrun/global/error/exception/ErrorCode.java
@@ -15,9 +15,10 @@ public enum ErrorCode {
     INVALID_TYPE_VALUE(400, "C005", " Invalid Type Value"),
     HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied"),
 
-    // Member
-    EMAIL_DUPLICATION(400, "M001", "Email is Duplication"),
-    LOGIN_INPUT_INVALID(400, "M002", "Login input is invalid"),
+    // Auth
+    EMAIL_DUPLICATION(400, "A001", "Email is Duplication"),
+    LOGIN_INPUT_INVALID(400, "A002", "Login input is invalid"),
+    UNAUTHORIZED(401, "A003", "UnAuthorized"),
 
     // Coupon
     COUPON_ALREADY_USE(400, "CO001", "Coupon was already used"),

--- a/src/main/java/artrun/artrun/global/error/exception/InvalidValueException.java
+++ b/src/main/java/artrun/artrun/global/error/exception/InvalidValueException.java
@@ -1,0 +1,12 @@
+package artrun.artrun.global.error.exception;
+
+public class InvalidValueException extends BusinessException {
+
+    public InvalidValueException(String value) {
+        super(value, ErrorCode.INVALID_INPUT_VALUE);
+    }
+
+    public InvalidValueException(String value, ErrorCode errorCode) {
+        super(value, errorCode);
+    }
+}

--- a/src/main/java/artrun/artrun/global/error/exception/InvalidWktException.java
+++ b/src/main/java/artrun/artrun/global/error/exception/InvalidWktException.java
@@ -3,7 +3,7 @@ package artrun.artrun.global.error.exception;
 /**
  * org.locationtech.jts.io.ParseException 예외 전환
  */
-public class InvalidWktException extends RuntimeException {
+public class InvalidWktException extends InvalidValueException {
 
     public InvalidWktException(String msg) {
         super(msg);

--- a/src/test/java/artrun/artrun/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/artrun/artrun/domain/auth/controller/AuthControllerTest.java
@@ -3,9 +3,8 @@ package artrun.artrun.domain.auth.controller;
 import artrun.artrun.domain.BaseTestController;
 import artrun.artrun.domain.auth.dto.AuthRequestDto;
 import artrun.artrun.domain.auth.dto.AuthResponseDto;
-import artrun.artrun.domain.auth.dto.TokenDto;
+import artrun.artrun.domain.auth.dto.TokenResponseDto;
 import artrun.artrun.domain.auth.service.AuthService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,7 +66,7 @@ class AuthControllerTest extends BaseTestController {
         authRequestDto.setPassword(password);
 
         // when
-        TokenDto tokenDto = TokenDto.builder()
+        TokenResponseDto tokenDto = TokenResponseDto.builder()
                 .grantType("bearer")
                 .accessToken("testAccessToken")
                 .refreshToken("testRefreshToken")

--- a/src/test/java/artrun/artrun/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/artrun/artrun/domain/auth/controller/AuthControllerTest.java
@@ -4,7 +4,10 @@ import artrun.artrun.domain.BaseTestController;
 import artrun.artrun.domain.auth.dto.AuthRequestDto;
 import artrun.artrun.domain.auth.dto.AuthResponseDto;
 import artrun.artrun.domain.auth.dto.TokenResponseDto;
+import artrun.artrun.domain.auth.exception.AuthenticationException;
 import artrun.artrun.domain.auth.service.AuthService;
+import artrun.artrun.domain.auth.service.CustomUserDetailsService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +16,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static artrun.artrun.global.error.exception.ErrorCode.EMAIL_DUPLICATION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -30,18 +34,26 @@ class AuthControllerTest extends BaseTestController {
     @MockBean
     AuthService authService;
 
+    @MockBean
+    CustomUserDetailsService customUserDetailsService;
+
+    AuthRequestDto authRequestDto = new AuthRequestDto();
+
+    @BeforeEach
+    public void setup() {
+        String email = "nnyy@gmail.com";
+        String password = "password01";
+        authRequestDto.setEmail(email);
+        authRequestDto.setPassword(password);
+    }
+
     @Test
     @DisplayName("email과 password를 넘기면 회원가입을 한 뒤 성공하면 email을 반환한다.")
     void signupSuccess() throws Exception {
         // given
-        String email = "nnyy@gmail.com";
-        String password = "password01";
-        AuthRequestDto authRequestDto = new AuthRequestDto();
-        authRequestDto.setEmail(email);
-        authRequestDto.setPassword(password);
 
         // when
-        AuthResponseDto authResponseDto = new AuthResponseDto(email);
+        AuthResponseDto authResponseDto = new AuthResponseDto(authRequestDto.getEmail());
         when(authService.signup(any())).thenReturn(authResponseDto);
 
         // then
@@ -51,8 +63,53 @@ class AuthControllerTest extends BaseTestController {
                         .contentType(MediaType.APPLICATION_JSON)
                         .with(csrf()))
                 .andDo(print())
-                .andExpect(jsonPath("email").value(email))
+                .andExpect(jsonPath("email").value(authRequestDto.getEmail()))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("회원가입 시 email 형식이 틀리면 ErrorResponse 객체를 반환한다.")
+    void singupEmailValid() throws Exception {
+        // given
+        AuthRequestDto authRequestDto = new AuthRequestDto();
+        String email = "nnyy";
+        String password = "password01";
+        authRequestDto.setEmail(email);
+        authRequestDto.setPassword(password);
+
+        // when
+        AuthResponseDto authResponseDto = new AuthResponseDto(authRequestDto.getEmail());
+        when(authService.signup(any())).thenReturn(authResponseDto);
+
+        // then
+        String requestBody = objectMapper.writeValueAsString(authRequestDto);
+        mockMvc.perform(post("/auth/signup")
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("code").value("C001"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("회원가입 시 email이 중복이면 ErrorResponse 객체를 반환한다.")
+    void singupEmailDuplication() throws Exception {
+        // given
+
+        // when
+        AuthResponseDto authResponseDto = new AuthResponseDto(authRequestDto.getEmail());
+        when(authService.signup(any())).thenThrow(new AuthenticationException(EMAIL_DUPLICATION));
+
+        // then
+        String requestBody = objectMapper.writeValueAsString(authRequestDto);
+        mockMvc.perform(post("/auth/signup")
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("code").value("A001"))
+                .andExpect(status().is4xxClientError());
     }
 
     @Test
@@ -86,10 +143,6 @@ class AuthControllerTest extends BaseTestController {
                 .andExpect(jsonPath("refreshToken").value(tokenDto.getRefreshToken()))
                 .andExpect(jsonPath("accessTokenExpiresIn").value(tokenDto.getAccessTokenExpiresIn()))
                 .andExpect(status().isOk());
-    }
-
-    @Test
-    void loginFail() {
     }
 
     @Test

--- a/src/test/java/artrun/artrun/domain/route/controller/RouteControllerTest.java
+++ b/src/test/java/artrun/artrun/domain/route/controller/RouteControllerTest.java
@@ -1,10 +1,7 @@
 package artrun.artrun.domain.route.controller;
 
 import artrun.artrun.domain.BaseTestController;
-import artrun.artrun.domain.route.dto.RouteFinishRequestDto;
-import artrun.artrun.domain.route.dto.RouteFinishResponseDto;
-import artrun.artrun.domain.route.dto.RouteStartRequestDto;
-import artrun.artrun.domain.route.dto.RouteStartResponseDto;
+import artrun.artrun.domain.route.dto.*;
 import artrun.artrun.domain.route.repository.RouteRepository;
 import artrun.artrun.domain.route.service.RouteFindService;
 import artrun.artrun.domain.route.service.RouteRunService;
@@ -16,9 +13,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import javax.persistence.EntityNotFoundException;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -40,7 +40,19 @@ class RouteControllerTest extends BaseTestController {
     RouteRepository routeRepository;
 
     @Test
-    void get() {
+    @DisplayName("경로의 아이디를 조회할 때, 경로의 아이디가 없으면 ENTITY_NOT_FOUND 예외를 반환한다.")
+    void getRouteNotfound() throws Exception{
+        // given
+
+        // when
+        when(routeFindService.get(any())).thenThrow(new EntityNotFoundException("not found"));
+
+        // then
+        mockMvc.perform(get("/route/100")
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("code").value("C003"))
+                .andExpect(status().is4xxClientError());
     }
 
     @Test


### PR DESCRIPTION
### 목적

- `GlobalExceptionHandler` 구현
- 공통의 `ErrorResponse` 구현
- Exception에 해당하는 테스트 케이스 추가

### Todo

- [x]  /login email 형식
    - [x]  test
- [x]  /login empty
    - [ ]  test
- [x]  /signup email 중복일 때
    - [x]  test
- [x]  /login email, password 매칭 안될 때
    [https://velog.io/@peppermint100/Spring-Boot-예외-처리](https://velog.io/@peppermint100/Spring-Boot-%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%AC)
    
    - [ ]  test
- [x]  /route/{routeId} 없을 때
    - [x]  test
- [x]  /route start 요소 형식
    - [ ]  test
- [x]  credential 없을 때 Exception

### 참고

- [https://cheese10yun.github.io/spring-guide-exception/](https://cheese10yun.github.io/spring-guide-exception/)