### PR TITLE
Feat/recommendation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -45,6 +46,7 @@ dependencies {
 
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'io.leonard:google-polyline-codec:0.0.2'
 
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/src/main/java/artrun/artrun/domain/auth/SecurityUtil.java
+++ b/src/main/java/artrun/artrun/domain/auth/SecurityUtil.java
@@ -3,6 +3,7 @@ package artrun.artrun.domain.auth;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,11 +30,11 @@ public class SecurityUtil {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || authentication.getName() == null) {
-            throw new AuthenticationServiceException("Security Context에 인증 정보가 없습니다.");
+            throw new AuthorizationServiceException("Security Context에 인증 정보가 없습니다.");
         }
 
         if (Long.parseLong(authentication.getName()) != memberId) {
-            throw new AuthenticationServiceException("토큰과 일치하지 않는 memberId입니다.");
+            throw new AuthorizationServiceException("토큰과 일치하지 않는 memberId입니다.");
         }
 
         return true;

--- a/src/main/java/artrun/artrun/domain/auth/exception/AuthorizationException.java
+++ b/src/main/java/artrun/artrun/domain/auth/exception/AuthorizationException.java
@@ -1,0 +1,14 @@
+package artrun.artrun.domain.auth.exception;
+
+import artrun.artrun.global.error.exception.BusinessException;
+import artrun.artrun.global.error.exception.ErrorCode;
+
+public class AuthorizationException extends BusinessException {
+    public AuthorizationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthorizationException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/artrun/artrun/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/controller/RecommendationController.java
@@ -4,6 +4,8 @@ import artrun.artrun.domain.recommendation.dto.RecommendationResponseDto;
 import artrun.artrun.domain.recommendation.service.RecommendationService;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,10 +19,10 @@ public class RecommendationController {
 
     private final RecommendationService recommendationService;
 
-    @ApiOperation(value = "추천 경로들 보기", notes = "희망 거리(m)를 넘기면 추천 경로 리스트 반환")
+    @ApiOperation(value = "추천 경로들 보기", notes = "희망 거리(m)와 pageable을 넘기면 추천 경로 리스트 반환")
     @GetMapping("/recommendations")
-    public ResponseEntity<List<RecommendationResponseDto>> getRecommendations(@RequestParam int distance, Long lastRecommendationId) {
-        return ResponseEntity.ok(recommendationService.getRecommendationsByDistance(distance, lastRecommendationId));
+    public ResponseEntity<List<RecommendationResponseDto>> getRecommendations(@RequestParam int distance, @PageableDefault(size = 5) Pageable pageable) {
+        return ResponseEntity.ok(recommendationService.getRecommendationsByDistance(distance, pageable));
     }
 
 }

--- a/src/main/java/artrun/artrun/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/controller/RecommendationController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,6 +24,12 @@ public class RecommendationController {
     @GetMapping("/recommendations")
     public ResponseEntity<List<RecommendationResponseDto>> getRecommendations(@RequestParam int distance, @PageableDefault(size = 5) Pageable pageable) {
         return ResponseEntity.ok(recommendationService.getRecommendationsByDistance(distance, pageable));
+    }
+
+    @ApiOperation(value = "보정된 추천 경로 출력", notes = "중심 좌표와 추천 아이디를 넘기면 보정된 추천 경로 반환")
+    @GetMapping("/recommendation/{recommendationId}/adjust")
+    public ResponseEntity<RecommendationResponseDto> getAdjustedRecommendation(@PathVariable Long recommendationId, @RequestParam Double lat, Double lng) {
+        return ResponseEntity.ok(recommendationService.adjustRecommendationToCenter(recommendationId, lat, lng));
     }
 
 }

--- a/src/main/java/artrun/artrun/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/controller/RecommendationController.java
@@ -1,0 +1,26 @@
+package artrun.artrun.domain.recommendation.controller;
+
+import artrun.artrun.domain.recommendation.dto.RecommendationResponseDto;
+import artrun.artrun.domain.recommendation.service.RecommendationService;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class RecommendationController {
+
+    private final RecommendationService recommendationService;
+
+    @ApiOperation(value = "추천 경로들 보기", notes = "희망 거리(m)를 넘기면 추천 경로 리스트 반환")
+    @GetMapping("/recommendations")
+    public ResponseEntity<List<RecommendationResponseDto>> getRecommendations(@RequestParam int distance, Long lastRecommendationId) {
+        return ResponseEntity.ok(recommendationService.getRecommendationsByDistance(distance, lastRecommendationId));
+    }
+
+}

--- a/src/main/java/artrun/artrun/domain/recommendation/domain/Recommendation.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/domain/Recommendation.java
@@ -1,0 +1,33 @@
+package artrun.artrun.domain.recommendation.domain;
+
+import artrun.artrun.domain.BaseEntity;
+import lombok.*;
+import org.locationtech.jts.geom.Geometry;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "recommendations")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Recommendation extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "recommendation_id", updatable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private Geometry route;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private int distance;
+
+    private Long usedCount;
+
+}

--- a/src/main/java/artrun/artrun/domain/recommendation/dto/RecommendationResponseDto.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/dto/RecommendationResponseDto.java
@@ -1,0 +1,24 @@
+package artrun.artrun.domain.recommendation.dto;
+
+import artrun.artrun.domain.recommendation.domain.Recommendation;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecommendationResponseDto {
+    private Long id;
+    private String wktRoute;
+    private String title;
+    private int distance;
+
+    public static RecommendationResponseDto of(Recommendation recommendation) {
+        return RecommendationResponseDto.builder()
+                .id(recommendation.getId())
+                .wktRoute(recommendation.getRoute().toString())
+                .title(recommendation.getTitle())
+                .distance(recommendation.getDistance())
+                .build();
+    }
+}

--- a/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepository.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepository.java
@@ -4,6 +4,6 @@ import artrun.artrun.domain.recommendation.domain.Recommendation;
 
 import java.util.List;
 
-public interface RecommendtaionCustomRepository {
+public interface RecommendationCustomRepository {
     List<Recommendation> getRecommendationsByDistance(int distance, Long lastRecommendationId);
 }

--- a/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepository.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepository.java
@@ -1,9 +1,10 @@
 package artrun.artrun.domain.recommendation.repository;
 
 import artrun.artrun.domain.recommendation.domain.Recommendation;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface RecommendationCustomRepository {
-    List<Recommendation> getRecommendationsByDistance(int distance, Long lastRecommendationId);
+    List<Recommendation> getRecommendationsByDistance(int distance, Pageable pageable);
 }

--- a/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepositoryImpl.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepositoryImpl.java
@@ -1,0 +1,12 @@
+package artrun.artrun.domain.recommendation.repository;
+
+import artrun.artrun.domain.recommendation.domain.Recommendation;
+
+import java.util.List;
+
+public class RecommendationCustomRepositoryImpl implements RecommendtaionCustomRepository{
+    @Override
+    public List<Recommendation> getRecommendationsByDistance(int distance, Long lastRecommendationId) {
+        return null;
+    }
+}

--- a/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepositoryImpl.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepositoryImpl.java
@@ -1,12 +1,46 @@
 package artrun.artrun.domain.recommendation.repository;
 
+import artrun.artrun.domain.recommendation.domain.QRecommendation;
 import artrun.artrun.domain.recommendation.domain.Recommendation;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-public class RecommendationCustomRepositoryImpl implements RecommendtaionCustomRepository{
+import static artrun.artrun.domain.recommendation.domain.QRecommendation.recommendation;
+import static artrun.artrun.domain.route.domain.QRoute.route;
+
+@Transactional(readOnly = true)
+@Repository
+public class RecommendationCustomRepositoryImpl implements RecommendationCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final int DEFAULT_PAGE_SIZE = 5;
+
+    public RecommendationCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+
     @Override
     public List<Recommendation> getRecommendationsByDistance(int distance, Long lastRecommendationId) {
-        return null;
+        final QRecommendation recommendation = QRecommendation.recommendation;
+
+        return jpaQueryFactory.selectFrom(recommendation)
+                .where(recommendation.distance.between(distance*0.5,distance*1.5))
+                .where(ltRecommendationId(lastRecommendationId))
+                .orderBy(recommendation.usedCount.desc(), recommendation.id.desc())
+                .limit(DEFAULT_PAGE_SIZE)
+                .fetch();
+    }
+
+    private BooleanExpression ltRecommendationId(Long recommendationId) {
+        if (recommendationId == null) {
+            return null; // BooleanExpression 자리에 null이 반환되면 조건문에서 자동으로 제거된다
+        }
+        return recommendation.id.lt(recommendationId);
     }
 }

--- a/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepositoryImpl.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import artrun.artrun.domain.recommendation.domain.QRecommendation;
 import artrun.artrun.domain.recommendation.domain.Recommendation;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,29 +19,20 @@ public class RecommendationCustomRepositoryImpl implements RecommendationCustomR
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    private final int DEFAULT_PAGE_SIZE = 5;
-
     public RecommendationCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
 
     @Override
-    public List<Recommendation> getRecommendationsByDistance(int distance, Long lastRecommendationId) {
+    public List<Recommendation> getRecommendationsByDistance(int distance, Pageable pageable) {
         final QRecommendation recommendation = QRecommendation.recommendation;
 
         return jpaQueryFactory.selectFrom(recommendation)
                 .where(recommendation.distance.between(distance*0.5,distance*1.5))
-                .where(ltRecommendationId(lastRecommendationId))
                 .orderBy(recommendation.usedCount.desc(), recommendation.id.desc())
-                .limit(DEFAULT_PAGE_SIZE)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
-    }
-
-    private BooleanExpression ltRecommendationId(Long recommendationId) {
-        if (recommendationId == null) {
-            return null; // BooleanExpression 자리에 null이 반환되면 조건문에서 자동으로 제거된다
-        }
-        return recommendation.id.lt(recommendationId);
     }
 }

--- a/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationRepository.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationRepository.java
@@ -1,0 +1,7 @@
+package artrun.artrun.domain.recommendation.repository;
+
+import artrun.artrun.domain.recommendation.domain.Recommendation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendationRepository extends JpaRepository<Recommendation, Long>, RecommendtaionCustomRepository {
+}

--- a/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationRepository.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendationRepository.java
@@ -3,5 +3,5 @@ package artrun.artrun.domain.recommendation.repository;
 import artrun.artrun.domain.recommendation.domain.Recommendation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RecommendationRepository extends JpaRepository<Recommendation, Long>, RecommendtaionCustomRepository {
+public interface RecommendationRepository extends JpaRepository<Recommendation, Long>, RecommendationCustomRepository {
 }

--- a/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendtaionCustomRepository.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/repository/RecommendtaionCustomRepository.java
@@ -1,0 +1,9 @@
+package artrun.artrun.domain.recommendation.repository;
+
+import artrun.artrun.domain.recommendation.domain.Recommendation;
+
+import java.util.List;
+
+public interface RecommendtaionCustomRepository {
+    List<Recommendation> getRecommendationsByDistance(int distance, Long lastRecommendationId);
+}

--- a/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
@@ -1,20 +1,25 @@
 package artrun.artrun.domain.recommendation.service;
 
+import artrun.artrun.domain.recommendation.domain.Recommendation;
 import artrun.artrun.domain.recommendation.dto.RecommendationResponseDto;
 import artrun.artrun.domain.recommendation.repository.RecommendationRepository;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class RecommendationService {
 
     private final RecommendationRepository recommendationRepository;
 
+    @Transactional(readOnly = true)
     public List<RecommendationResponseDto> getRecommendationsByDistance(int distance, Pageable pageable) {
         return recommendationRepository.getRecommendationsByDistance(distance, pageable)
                 .stream()
@@ -22,4 +27,21 @@ public class RecommendationService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public RecommendationResponseDto adjustRecommendationToCenter(Long recommendationId, Double lat, Double lng) {
+        Recommendation recommendation = recommendationRepository.getById(recommendationId);
+
+        // 1. centerPosition과 centroid의 차이만큼 평행이동
+        double latOffset = lat - recommendation.getRoute().getCentroid().getCoordinate().y;
+        double lngOffset = lng - recommendation.getRoute().getCentroid().getCoordinate().x;
+
+        for(Coordinate coordinate : recommendation.getRoute().getCoordinates()) {
+            coordinate.setX(coordinate.getX() + lngOffset);
+            coordinate.setY(coordinate.getY() + latOffset);
+        }
+
+        // TODO apply OSRM nearest
+
+        return RecommendationResponseDto.of(recommendation);
+    }
 }

--- a/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
@@ -1,0 +1,20 @@
+package artrun.artrun.domain.recommendation.service;
+
+import artrun.artrun.domain.recommendation.domain.Recommendation;
+import artrun.artrun.domain.recommendation.repository.RecommendationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationService {
+
+    private final RecommendationRepository recommendationRepository;
+
+    public List<Recommendation> getRecommendationsByDistance(int distance, Long lastRecommendationId) {
+        return recommendationRepository.getRecommendationsByDistance(distance, lastRecommendationId);
+    }
+
+}

--- a/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
@@ -3,6 +3,7 @@ package artrun.artrun.domain.recommendation.service;
 import artrun.artrun.domain.recommendation.dto.RecommendationResponseDto;
 import artrun.artrun.domain.recommendation.repository.RecommendationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -14,8 +15,8 @@ public class RecommendationService {
 
     private final RecommendationRepository recommendationRepository;
 
-    public List<RecommendationResponseDto> getRecommendationsByDistance(int distance, Long lastRecommendationId) {
-        return recommendationRepository.getRecommendationsByDistance(distance, lastRecommendationId)
+    public List<RecommendationResponseDto> getRecommendationsByDistance(int distance, Pageable pageable) {
+        return recommendationRepository.getRecommendationsByDistance(distance, pageable)
                 .stream()
                 .map(RecommendationResponseDto::of)
                 .collect(Collectors.toList());

--- a/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
@@ -1,11 +1,12 @@
 package artrun.artrun.domain.recommendation.service;
 
-import artrun.artrun.domain.recommendation.domain.Recommendation;
+import artrun.artrun.domain.recommendation.dto.RecommendationResponseDto;
 import artrun.artrun.domain.recommendation.repository.RecommendationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -13,8 +14,11 @@ public class RecommendationService {
 
     private final RecommendationRepository recommendationRepository;
 
-    public List<Recommendation> getRecommendationsByDistance(int distance, Long lastRecommendationId) {
-        return recommendationRepository.getRecommendationsByDistance(distance, lastRecommendationId);
+    public List<RecommendationResponseDto> getRecommendationsByDistance(int distance, Long lastRecommendationId) {
+        return recommendationRepository.getRecommendationsByDistance(distance, lastRecommendationId)
+                .stream()
+                .map(RecommendationResponseDto::of)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/artrun/artrun/domain/recommendation/service/RecommendationService.java
@@ -50,7 +50,7 @@ public class RecommendationService {
         Geometry geometry = new GeometryFactory().createLineString(coordinates);
 
         // 2. OSRM API 기반 맵 매칭
-        Geometry matchedRoute = osrmRequester.match(geometry);
+        Geometry matchedRoute = osrmRequester.requestMatch(geometry);
 
         return RecommendationResponseDto.builder()
                 .id(recommendation.getId())

--- a/src/main/java/artrun/artrun/domain/route/controller/RouteController.java
+++ b/src/main/java/artrun/artrun/domain/route/controller/RouteController.java
@@ -2,7 +2,7 @@ package artrun.artrun.domain.route.controller;
 
 import artrun.artrun.domain.route.dto.*;
 import artrun.artrun.domain.route.service.RouteFindService;
-import artrun.artrun.domain.route.service.RouteRunService;
+import artrun.artrun.domain.route.service.RouteService;
 import io.swagger.annotations.ApiOperation;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 public class RouteController {
 
-    private final RouteRunService routeRunService;
+    private final RouteService routeService;
 
     private final RouteFindService routeFindService;
 
@@ -24,16 +24,23 @@ public class RouteController {
         return ResponseEntity.ok(routeFindService.get(routeId));
     }
 
+    @ApiOperation(value= "routeId로 Route 삭제")
+    @DeleteMapping("/route/{routeId}")
+    public ResponseEntity<Void> delete(@PathVariable Long routeId) {
+        routeService.deleteRoute(routeId);
+        return ResponseEntity.noContent().build();
+    }
+
     @ApiOperation(value="달리기 시작", notes = "목표 경로 그리기가 끝나고, 시작 버튼을 누를 때")
     @PostMapping("/route/start")
     public ResponseEntity<RouteStartResponseDto> start(@RequestBody RouteStartRequestDto routeStartRequestDto) {
-        return ResponseEntity.ok(routeRunService.start(routeStartRequestDto));
+        return ResponseEntity.ok(routeService.startRoute(routeStartRequestDto));
     }
 
     @ApiOperation(value="달리기 종료", notes = "달리기 종료 및 기록카드 작성 후, 저장 버튼을 누를 때")
     @PostMapping("/route/finish")
     public ResponseEntity<RouteFinishResponseDto> finish(@RequestBody RouteFinishRequestDto routeFinishRequestDto) {
-        return ResponseEntity.ok(routeRunService.finish(routeFinishRequestDto));
+        return ResponseEntity.ok(routeService.finishRoute(routeFinishRequestDto));
     }
 
     @ApiOperation(value="소셜 - 최신기록", notes="소셜 피드에서 Routes를 반환함 (정렬 기준: 최신순)")

--- a/src/main/java/artrun/artrun/domain/route/domain/Route.java
+++ b/src/main/java/artrun/artrun/domain/route/domain/Route.java
@@ -55,4 +55,8 @@ public class Route extends BaseEntity {
         this.thickness = route.thickness;
         this.isPublic = route.isPublic;
     }
+
+    public Boolean isOwnedBy(Long memberId) {
+        return this.member.getId() == memberId;
+    }
 }

--- a/src/main/java/artrun/artrun/domain/route/service/RouteFindService.java
+++ b/src/main/java/artrun/artrun/domain/route/service/RouteFindService.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class RouteFindService {
 

--- a/src/main/java/artrun/artrun/domain/route/service/RouteService.java
+++ b/src/main/java/artrun/artrun/domain/route/service/RouteService.java
@@ -1,6 +1,7 @@
 package artrun.artrun.domain.route.service;
 
 import artrun.artrun.domain.auth.SecurityUtil;
+import artrun.artrun.domain.auth.exception.AuthorizationException;
 import artrun.artrun.domain.route.domain.Route;
 import artrun.artrun.domain.route.dto.RouteFinishRequestDto;
 import artrun.artrun.domain.route.dto.RouteFinishResponseDto;
@@ -11,26 +12,36 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static artrun.artrun.global.error.exception.ErrorCode.UNAUTHORIZED;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class RouteRunService {
+public class RouteService {
 
     private final RouteRepository routeRepository;
 
-    public RouteStartResponseDto start(RouteStartRequestDto routeStartRequestDto) {
+    public RouteStartResponseDto startRoute(RouteStartRequestDto routeStartRequestDto) {
         SecurityUtil.isAuthorizedByMemberId(routeStartRequestDto.getMemberId());
 
         Route route = routeStartRequestDto.toRoute();
         return RouteStartResponseDto.of(routeRepository.save(route));
     }
 
-    public RouteFinishResponseDto finish(RouteFinishRequestDto routeFinishRequestDto) {
+    public RouteFinishResponseDto finishRoute(RouteFinishRequestDto routeFinishRequestDto) {
         SecurityUtil.isAuthorizedByMemberId(routeFinishRequestDto.getMemberId());
 
         Route route = routeRepository.getByIdAndMemberId(routeFinishRequestDto.getRouteId(), routeFinishRequestDto.getMemberId());
         route.updateAtFinish(routeFinishRequestDto.toRoute());
 
         return RouteFinishResponseDto.of(routeRepository.save(route));
+    }
+
+    public void deleteRoute(Long routeId) {
+        Route route = routeRepository.getById(routeId);
+        if(!route.isOwnedBy(SecurityUtil.getCurrentMemberId())) {
+            throw new AuthorizationException("해당 경로 작성자와 일치하지 않는 memberId입니다.", UNAUTHORIZED);
+        }
+        routeRepository.delete(route);
     }
 }

--- a/src/main/java/artrun/artrun/global/util/requester/OsrmRequester.java
+++ b/src/main/java/artrun/artrun/global/util/requester/OsrmRequester.java
@@ -4,55 +4,64 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.leonard.PolylineUtils;
 import io.leonard.Position;
-import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.*;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
+@Slf4j
 public class OsrmRequester {
+    /**
+     * OSRM match로 맵매칭 해보고, 맵매칭 결과가 있으면 맵매칭된 geometry를 반환 없으면 그대로 반환.
+     * @param geometry
+     * @return Geometry
+     */
+    public Geometry requestMatch(Geometry geometry) {
+        try {
+            log.info("requestMatch - origin: " + geometry.toString());
+            String positions = PolylineUtils.encode(Arrays.stream(geometry.getCoordinates()).map(c -> Position.fromLngLat(c.getX(), c.getY())).collect(Collectors.toList()), 5);
 
-    // TODO refactor it
-    @SneakyThrows
-    public Geometry match(Geometry geometries) {
+            String jsonResult = receiveMatchResponse(positions);
 
-        List<Position> positions = Arrays.stream(geometries.getCoordinates()).map(c -> Position.fromLngLat(c.getX(), c.getY())).collect(Collectors.toList());
-        String encodedPositions = PolylineUtils.encode(positions, 5);
-        System.out.println("encodedPositions = " + encodedPositions);
-        String jsonResult = WebClient.create().get()
+            // to get matchedPositions
+            Map<String, Object> jsonMap = new ObjectMapper().readValue(jsonResult, new TypeReference<Map<String, Object>>() {});
+            LinkedHashMap matchings = (LinkedHashMap) ((ArrayList) jsonMap.get("matchings")).get(0);
+            String matchedGeometry = (String) matchings.get("geometry");
+            List<Position> matchedPositions = PolylineUtils.decode(matchedGeometry, 5);
+
+            ArrayList<Coordinate> coordinateArrayList = new ArrayList<>();
+            for (Position position : matchedPositions) {
+                coordinateArrayList.add(new Coordinate(position.getLongitude(), position.getLatitude()));
+            }
+            Coordinate[] coordinates = coordinateArrayList.toArray(Coordinate[]::new);
+
+            log.info("requestMatch - matched: " + new GeometryFactory().createLineString(coordinates).toString());
+            return new GeometryFactory().createLineString(coordinates);
+        } catch (Exception exception) {
+            log.info("requestMatch - catch exception");
+            return geometry;
+        }
+    }
+
+    private String receiveMatchResponse(String positions) {
+        return WebClient.create().get()
                 .uri(uriBuilder ->
                         uriBuilder
                                 .scheme("http")
                                 .host("router.project-osrm.org")
-                                .pathSegment("match","v1", "foot", "polyline({encodedPosition})")
-                                .build(encodedPositions))
+                                .pathSegment("match", "v1", "foot", "polyline({encodedPosition})")
+                                .build(positions))
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
-                .bodyToMono(String.class)
-                .block();
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Object> jsonMap = objectMapper.readValue(jsonResult, new TypeReference<Map<String, Object>>() {});
-        if (jsonMap.get("code").equals("Ok")) {
-            //noinspection unchecked
-            ArrayList matchings = (ArrayList) jsonMap.get("matchings");
-            LinkedHashMap newMatchings = (LinkedHashMap) matchings.get(0);
-            String matchedGeometry = (String) newMatchings.get("geometry");
-            List<Position> matchedPositions = PolylineUtils.decode(matchedGeometry, 5);
-            ArrayList<Coordinate> coordinateArrayList = new ArrayList<>();
-
-            for(Position position: matchedPositions) {
-                coordinateArrayList.add(new Coordinate(position.getLongitude(), position.getLatitude()));
-            }
-            Coordinate[] coordinates = coordinateArrayList.toArray(Coordinate[]::new);
-            return new GeometryFactory().createLineString(coordinates);
-        } else {
-            return geometries;
-        }
+                .onStatus(HttpStatus::isError, response -> Mono.error(new RuntimeException("convert fail")))
+                .bodyToMono(String.class).block();
     }
 
 }

--- a/src/main/java/artrun/artrun/global/util/requester/OsrmRequester.java
+++ b/src/main/java/artrun/artrun/global/util/requester/OsrmRequester.java
@@ -1,0 +1,58 @@
+package artrun.artrun.global.util.requester;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.leonard.PolylineUtils;
+import io.leonard.Position;
+import lombok.SneakyThrows;
+import org.locationtech.jts.geom.*;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class OsrmRequester {
+
+    // TODO refactor it
+    @SneakyThrows
+    public Geometry match(Geometry geometries) {
+
+        List<Position> positions = Arrays.stream(geometries.getCoordinates()).map(c -> Position.fromLngLat(c.getX(), c.getY())).collect(Collectors.toList());
+        String encodedPositions = PolylineUtils.encode(positions, 5);
+        System.out.println("encodedPositions = " + encodedPositions);
+        String jsonResult = WebClient.create().get()
+                .uri(uriBuilder ->
+                        uriBuilder
+                                .scheme("http")
+                                .host("router.project-osrm.org")
+                                .pathSegment("match","v1", "foot", "polyline({encodedPosition})")
+                                .build(encodedPositions))
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> jsonMap = objectMapper.readValue(jsonResult, new TypeReference<Map<String, Object>>() {});
+        if (jsonMap.get("code").equals("Ok")) {
+            //noinspection unchecked
+            ArrayList matchings = (ArrayList) jsonMap.get("matchings");
+            LinkedHashMap newMatchings = (LinkedHashMap) matchings.get(0);
+            String matchedGeometry = (String) newMatchings.get("geometry");
+            List<Position> matchedPositions = PolylineUtils.decode(matchedGeometry, 5);
+            ArrayList<Coordinate> coordinateArrayList = new ArrayList<>();
+
+            for(Position position: matchedPositions) {
+                coordinateArrayList.add(new Coordinate(position.getLongitude(), position.getLatitude()));
+            }
+            Coordinate[] coordinates = coordinateArrayList.toArray(Coordinate[]::new);
+            return new GeometryFactory().createLineString(coordinates);
+        } else {
+            return geometries;
+        }
+    }
+
+}

--- a/src/test/java/artrun/artrun/domain/recommendation/repository/RecommendationRepositoryTest.java
+++ b/src/test/java/artrun/artrun/domain/recommendation/repository/RecommendationRepositoryTest.java
@@ -3,6 +3,7 @@ package artrun.artrun.domain.recommendation.repository;
 import artrun.artrun.domain.recommendation.domain.Recommendation;
 import artrun.artrun.global.util.wktToGeometry;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -21,6 +22,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+// TODO CI/CD 에서 테스트할 수 있도록 수정
+@Disabled
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class RecommendationRepositoryTest {

--- a/src/test/java/artrun/artrun/domain/recommendation/repository/RecommendationRepositoryTest.java
+++ b/src/test/java/artrun/artrun/domain/recommendation/repository/RecommendationRepositoryTest.java
@@ -1,0 +1,70 @@
+package artrun.artrun.domain.recommendation.repository;
+
+import artrun.artrun.domain.recommendation.domain.Recommendation;
+import artrun.artrun.global.util.wktToGeometry;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RecommendationRepositoryTest {
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @PersistenceContext
+        private EntityManager entityManager;
+
+        @Bean
+        public JPAQueryFactory jpaQueryFactory() {
+            return new JPAQueryFactory(entityManager);
+        }
+    }
+
+    @Autowired
+    private RecommendationRepository recommendationRepository;
+
+    @DisplayName("recommendation 조회 첫번째")
+    @Test
+    void getRecommendationsByDistanceFirst() {
+        // given
+        int distance = 1302;
+        Geometry route = wktToGeometry.wktToGeometry("LINESTRING (30 10, 10 30, 40 40)");
+
+        List<Recommendation> recommendationList = new ArrayList<>();
+        for(int i =1; i<= 30; i++) {
+            recommendationList.add(Recommendation.builder()
+                    .id((long) i)
+                    .route(route)
+                    .distance(100 * i)
+                    .title("title" + i)
+                    .usedCount((long) i)
+                    .build());
+        }
+        recommendationRepository.saveAll(recommendationList);
+
+        // when
+        List<Recommendation> resultRecommendations = recommendationRepository.getRecommendationsByDistance(distance, null);
+
+        // then
+        assertThat(resultRecommendations).hasSize(5);
+        assertThat(resultRecommendations.get(0).getUsedCount()).isGreaterThan(resultRecommendations.get(1).getUsedCount());
+        assertThat(resultRecommendations.get(0).getUsedCount()).isEqualTo(19);
+    }
+}

--- a/src/test/java/artrun/artrun/domain/recommendation/repository/RecommendationRepositoryTest.java
+++ b/src/test/java/artrun/artrun/domain/recommendation/repository/RecommendationRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Pageable;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -63,7 +64,7 @@ class RecommendationRepositoryTest {
         recommendationRepository.saveAll(recommendationList);
 
         // when
-        List<Recommendation> resultRecommendations = recommendationRepository.getRecommendationsByDistance(distance, null);
+        List<Recommendation> resultRecommendations = recommendationRepository.getRecommendationsByDistance(distance, Pageable.ofSize(5));
 
         // then
         assertThat(resultRecommendations).hasSize(5);

--- a/src/test/java/artrun/artrun/domain/recommendation/service/RecommendationServiceTest.java
+++ b/src/test/java/artrun/artrun/domain/recommendation/service/RecommendationServiceTest.java
@@ -1,0 +1,60 @@
+package artrun.artrun.domain.recommendation.service;
+
+import artrun.artrun.domain.recommendation.domain.Recommendation;
+import artrun.artrun.domain.recommendation.dto.RecommendationResponseDto;
+import artrun.artrun.domain.recommendation.repository.RecommendationRepository;
+import artrun.artrun.global.util.wktToGeometry;
+import org.assertj.core.data.Percentage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Geometry;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationServiceTest {
+
+    @InjectMocks
+    RecommendationService recommendationService;
+
+    @Mock
+    RecommendationRepository recommendationRepository;
+
+    @DisplayName("route의 위도, 경도를 지도 중앙에 맞게 조정한다.")
+    @Test
+    void adjustRecommendationToCenter() {
+        // given
+        Geometry route = wktToGeometry.wktToGeometry("LINESTRING(127.2676797373322 37.004810894968806,127.26727204156194 37.005033659711664,127.26705746484075 37.005376373426046,127.266563938382 37.00518788107435,127.26600603890691 37.004656672841335,127.26669268441472 37.004228276401264,127.26701454949651 37.00373133350641,127.26759390664373 37.00361138128649,127.26821617913518 37.00325152349115,127.26855950188909 37.00403978120286,127.26890282464299 37.00489657379332,127.26907448601995 37.005890441100696,127.26849512887273 37.005907576629994,127.26832346749578 37.00523928812571,127.26791577172551 37.004879438036134)");
+
+        Recommendation recommendation = Recommendation.builder()
+                .id(1L)
+                .title("test")
+                .distance(1234)
+                .usedCount(1L)
+                .route(route.copy())
+                .build();
+        double lat = 37.55694939550261;
+        double lng = 126.98495686769316;
+
+        // when
+        when(recommendationRepository.getById(any())).thenReturn(recommendation);
+        RecommendationResponseDto recommendationResponseDto = recommendationService.adjustRecommendationToCenter(1L, lat, lng);
+
+        // then
+        Geometry modifiedRoute = wktToGeometry.wktToGeometry(recommendationResponseDto.getWktRoute());
+
+        assertThat(recommendationResponseDto.getWktRoute()).isNotEqualTo(route.toString());
+        assertThat(modifiedRoute.getCoordinate().getX()).isEqualTo(route.getCoordinate().getX()+(lng-route.getCentroid().getX()));
+        assertThat(modifiedRoute.getCoordinate().getY()).isEqualTo(route.getCoordinate().getY()+(lat-route.getCentroid().getY()));
+        assertThat(modifiedRoute.getCentroid().getX()).isCloseTo(lng, Percentage.withPercentage(0.00001));
+        assertThat(modifiedRoute.getCentroid().getY()).isCloseTo(lat, Percentage.withPercentage(0.00001));
+    }
+}

--- a/src/test/java/artrun/artrun/domain/route/controller/RouteControllerTest.java
+++ b/src/test/java/artrun/artrun/domain/route/controller/RouteControllerTest.java
@@ -4,7 +4,7 @@ import artrun.artrun.domain.BaseTestController;
 import artrun.artrun.domain.route.dto.*;
 import artrun.artrun.domain.route.repository.RouteRepository;
 import artrun.artrun.domain.route.service.RouteFindService;
-import artrun.artrun.domain.route.service.RouteRunService;
+import artrun.artrun.domain.route.service.RouteService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +31,7 @@ class RouteControllerTest extends BaseTestController {
     MockMvc mockMvc;
 
     @MockBean
-    RouteRunService routeRunService;
+    RouteService routeService;
 
     @MockBean
     RouteFindService routeFindService;
@@ -66,7 +66,7 @@ class RouteControllerTest extends BaseTestController {
 
         // when
         RouteStartResponseDto routeStartResponseDto = new RouteStartResponseDto(3L);
-        when(routeRunService.start(any())).thenReturn(routeStartResponseDto);
+        when(routeService.startRoute(any())).thenReturn(routeStartResponseDto);
 
         // then
         String requestBody = objectMapper.writeValueAsString(routeStartRequestDto);
@@ -98,7 +98,7 @@ class RouteControllerTest extends BaseTestController {
 
         // when
         RouteFinishResponseDto routeFinishResponseDto = new RouteFinishResponseDto(1L);
-        when(routeRunService.finish(any())).thenReturn(routeFinishResponseDto);
+        when(routeService.finishRoute(any())).thenReturn(routeFinishResponseDto);
 
         // then
         String requestBody = objectMapper.writeValueAsString(routeFinishRequestDto);

--- a/src/test/java/artrun/artrun/domain/route/service/RouteFindServiceTest.java
+++ b/src/test/java/artrun/artrun/domain/route/service/RouteFindServiceTest.java
@@ -1,0 +1,73 @@
+package artrun.artrun.domain.route.service;
+
+import artrun.artrun.domain.member.domain.Member;
+import artrun.artrun.domain.route.domain.Route;
+import artrun.artrun.domain.route.dto.RouteCardResponseDto;
+import artrun.artrun.domain.route.repository.RouteRepository;
+import artrun.artrun.global.util.wktToGeometry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Geometry;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RouteFindServiceTest {
+
+    @InjectMocks
+    RouteFindService routeFindService;
+
+    @Mock
+    RouteRepository routeRepository;
+
+    @DisplayName("getPublicRoutes 첫 페이지")
+    @Test
+    void getPublicRoutesFirst() {
+        // given
+        Geometry route = wktToGeometry.wktToGeometry("LINESTRING (30 10, 10 30, 40 40)");
+        Member member = Member.builder().id(1L).nickname("test").profileImg("testurl").build();
+        List<Route> routeList = new ArrayList<>();
+        for (int i = 1; i <= 30; i++) {
+            routeList.add(Route.builder()
+                    .id((long) i)
+                    .member(member)
+                    .targetRoute(route)
+                    .runRoute(route)
+                    .title("title" + i)
+                    .distance(1000)
+                    .time(3600)
+                    .kcal(104)
+                    .color("000000")
+                    .thickness((byte) 3)
+                    .isPublic(true)
+                    .build());
+        }
+        given(routeRepository.getPublicRoutes(any())).willReturn(routeList.subList(25,30));
+
+        // when
+        List<RouteCardResponseDto> routeCards = routeFindService.getPublicRoutes(null);
+
+        // then
+        assertThat(routeCards.get(0).getRouteId().equals(30L));
+        assertThat(routeCards.get(0).getNickname().equals(member.getNickname()));
+        assertThat(routeCards.get(0).getProfileImg().equals(member.getProfileImg()));
+        assertThat(routeCards.get(4).getRouteId().equals(26L));
+        assertThat(routeCards.get(4).getTitle().equals("title26"));
+        assertThat(routeCards.get(4).getWktRunRoute().equals(route.toString()));
+    }
+
+    @Test
+    void getMyRoutes() {
+    }
+}

--- a/src/test/java/artrun/artrun/domain/route/service/RouteServiceTest.java
+++ b/src/test/java/artrun/artrun/domain/route/service/RouteServiceTest.java
@@ -18,16 +18,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class RouteRunServiceTest {
+class RouteServiceTest {
 
     @InjectMocks
-    RouteRunService routeRunService;
+    RouteService routeService;
 
     @Mock
     RouteRepository routeRepository;
@@ -58,7 +58,7 @@ class RouteRunServiceTest {
         RouteStartRequestDto routeStartRequestDto = RouteStartRequestDto.builder().memberId(member.getId()).wktTargetRoute(String.valueOf(targetRoute)).build();
 
         // when
-        RouteStartResponseDto routeResponseDto = routeRunService.start(routeStartRequestDto);
+        RouteStartResponseDto routeResponseDto = routeService.startRoute(routeStartRequestDto);
 
         // then
         Route savedRoute = routeRepository.getById(routeResponseDto.getRouteId());
@@ -95,11 +95,43 @@ class RouteRunServiceTest {
         given(routeRepository.getByIdAndMemberId(any(), any())).willReturn(route);
 
         //when
-        RouteFinishResponseDto routeFinishResponseDto = routeRunService.finish(routeFinishRequestDto);
+        RouteFinishResponseDto routeFinishResponseDto = routeService.finishRoute(routeFinishRequestDto);
 
         //then
         Route savedRoute = routeRepository.getByIdAndMemberId(routeFinishResponseDto.getRouteId(), routeFinishRequestDto.getMemberId());
         assertThat(savedRoute.getRunRoute().toString().equals(wktRunRoute));
         assertThat(savedRoute.getTitle().equals(title));
+    }
+
+    @Test
+    @DisplayName("유저가 경로 아이디를 이용해 본인의 경로를 삭제한다.")
+    void deleteRoute() {
+        // given
+        Long memberId = 1L;
+        Long routeId = 1L;
+        Route route = Route.builder()
+                .id(1L)
+                .member(Member
+                        .builder()
+                        .id(memberId)
+                        .build()
+                )
+                .targetRoute(wktToGeometry.wktToGeometry("LINESTRING (29 11, 11 31, 42 41)"))
+                .runRoute(wktToGeometry.wktToGeometry("LINESTRING (29 11, 11 31, 42 41)"))
+                .title("title")
+                .distance(1235)
+                .time(295)
+                .kcal(64)
+                .color("B00020")
+                .thickness((byte) 3)
+                .isPublic(Boolean.TRUE)
+                .build();
+
+        // when
+        when(routeRepository.getById(any())).thenReturn(route);
+        when(SecurityUtil.getCurrentMemberId()).thenReturn(memberId);
+
+        // then
+        routeService.deleteRoute(routeId);
     }
 }


### PR DESCRIPTION

## 구현 내용

- [x]  /recommendations
    
    경로 추천 - 거리기준
    
    param: distance, pageable
    
    response: recommendation list
    
    order by usedCount 때문에 no offset을 쓸 수 없음 
    
    1. distance의 +- 50% 범위로 where 범위를 정한다. (1340-1340*50%≤ X ≤ 1340+1340*50%)
    2. OrderBy usedCount desc, id desc
    3. Paging 적용
    4. LIMIT 5
- [x]  /recommendation/adjust
    
    보정된 경로 출력
    
    param:
    
    - recommendationId
    - lat (`map.getCenter();`)
    - lng (`map.getCenter();`)
    
    response:
    
    - `RecommendationResponseDto`
    1. recommendation centroid와 centerPosition의 차이만큼 평행이동
    2. open street map 기반 map matching
        
        
    - [ ]  외부 api testcode 추가
        

## 참고
https://arthur-e.github.io/Wicket/sandbox-gmaps3.html
https://tecoble.techcourse.co.kr/post/2021-10-20-synchronous-asynchronous/
https://medium.com/@odysseymoon/spring-webclient-%EC%82%AC%EC%9A%A9%EB%B2%95-5f92d295edc0
http://project-osrm.org/docs/v5.24.0/api/#services